### PR TITLE
Fix broken migration command

### DIFF
--- a/docker-compose-init.sh
+++ b/docker-compose-init.sh
@@ -12,7 +12,7 @@ do
     sleep 5
 done
 
-python manage.py migrate --run-syncdb
+python manage.py migrate
 cat populate.py | python manage.py shell >/dev/null
 python manage.py update_index -r
 


### PR DESCRIPTION
--syncdb is not a valid option after the pinning of Django to 1.8.
Removing
